### PR TITLE
mysqli_close($db_handle); in services.php

### DIFF
--- a/services.php
+++ b/services.php
@@ -88,8 +88,6 @@ function servicetest($ip, $port)
     }
 }
 
-mysqli_close($db_handle);
-
 ?>
 
     </table>


### PR DESCRIPTION
Removed doubled mysqli_close($db_handle); reference causing Warning: mysqli_close(): Couldn't fetch mysqli in services.php on line 91